### PR TITLE
Allow tokens with escaped delimiter when surrounded by double quotation marks

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -4109,6 +4109,73 @@ class AnchoredToken(object):
     # For hashlib
     def __repr__(self):      return self.__class__.__name__ + "(" + repr(self.cached_str) + ")"
 
+def split_unquoted(string, delimiter=None):
+    """
+    Split a string on a given delimiter.
+
+    Similar to Python .split() but adds the ability to skip splitting on the
+    parts of the string that are surrounded by a double quotation mark (").
+
+    >>> split_unquoted('a "b c" d', ' ')
+    ['a', 'b c', 'd']
+
+    If the delimiter is not specified or is None, it is assumed to be a single
+    whitespace.
+
+    >>> split_unquoted('a "b c" d')
+    ['a', 'b c', 'd']
+    >>> split_unquoted('a "b c" d', None)
+    ['a', 'b c', 'd']
+
+    The double quotation mark (") can be escaped by placing (\) before it, and
+    the backslash (\) can be escaped by placing a backslash (\) before it.
+
+    Skipping any other character will raise a ValueError.
+    """
+    if delimiter is None:
+        delimiter = ' '
+    result = []
+    word = ''
+    quote_open = False
+    i = 0
+    while i < len(string):
+        # Try to skip the next char if we have a backslash
+        if string[i] == '\\' and i + 1 < len(string):
+            if string[i + 1] not in ['"', '\\']:
+                raise ValueError("Bad escape '\\{}', your can only escape one of the following chars: '\\' or '\"'.".format(string[i + 1]))
+            word += string[i + 1]
+            i = i + 2
+            continue
+
+        # Unescaped double quote should not be added to the string
+        if string[i] == '"':
+            quote_open = not quote_open
+            i = i + 1
+            continue
+
+        # Do not split inside a quoted string
+        if quote_open:
+            word += string[i]
+            i = i + 1
+        else:
+            if string[i: i + len(delimiter)] != delimiter:
+                word += string[i]
+                i = i + 1
+            else:
+                if word:
+                    result.append(word)
+                word = ''
+                i = i + len(delimiter)
+
+    if quote_open:
+        raise ValueError("The following line has unbalanced quotes: {}".format(string))
+
+    # If the end is reached without finding a split, add the remaining chars to the results
+    if word:
+        result.append(word)
+
+    return result
+
 def parse_tokenlist(tokenlist_file, first_line_num = 1):
     global token_lists
     global has_any_duplicate_tokens, has_any_wildcards, has_any_anchors
@@ -4134,7 +4201,7 @@ def parse_tokenlist(tokenlist_file, first_line_num = 1):
 
         # Remove the trailing newline, then split the line on the
         # specified delimiter (default: whitespace) to get a list of tokens
-        new_list.extend( line.strip("\r\n").split(args.delimiter) )
+        new_list.extend( split_unquoted(line.strip("\r\n"), args.delimiter) )
 
         # Ignore empty lines
         if new_list in ([None], [None, tstr('')]): continue

--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -2166,6 +2166,194 @@ class WalletBither(object):
         return False, count
 
 
+############### BIP-38 ###############
+
+def public_key_to_address(s):
+    ripemd160 = hash160(s)
+    return base58.b58encode_check((bytes([0x0]) + ripemd160))
+
+def compress(pub):
+    x = pub[1:33]
+    y = pub[33:]
+    if int.from_bytes(y, byteorder='big') % 2:
+        prefix = bytes([0x03])
+    else:
+        prefix = bytes([0x02])
+    return prefix + x
+
+def private_key_to_public_key(s):
+    sk = ecdsa.SigningKey.from_string(s, curve=ecdsa.SECP256k1)
+    return (bytes([0x04]) + sk.verifying_key.to_string())
+
+def bip38decrypt(password, encpriv, outputlotsequence=False):
+    COMPRESSION_FLAGBYTES = [0x20, 0x24, 0x28, 0x2c, 0x30, 0x34, 0x38, 0x3c, 0xe0, 0xe8, 0xf0, 0xf8]
+    LOTSEQUENCE_FLAGBYTES = [0x04, 0x0c, 0x14, 0x1c, 0x24, 0x2c, 0x34, 0x3c]
+
+    l_scrypt = pylibscrypt.scrypt
+
+    encpriv = base58.b58decode_check(encpriv)
+    assert len(encpriv) == 39
+    prefix = int.from_bytes(encpriv[:2], byteorder='big')
+    assert prefix == 0x0142 or prefix == 0x0143
+    flagbyte = int.from_bytes(encpriv[2:3], byteorder='big')
+    if prefix == 0x0142:
+        salt = encpriv[3:7]
+        msg1 = encpriv[7:23]
+        msg2 = encpriv[23:39]
+        scrypthash = l_scrypt(password, salt, 16384, 8, 8, 64)
+        key = scrypthash[32:]
+        aes = AESModeOfOperationECB(key)
+        msg1 = aes.decrypt(msg1)
+        msg2 = aes.decrypt(msg2)
+        half1 = int.from_bytes(msg1, byteorder='big') ^ int.from_bytes(scrypthash[:16], byteorder='big')
+        half2 = int.from_bytes(msg2, byteorder='big') ^ int.from_bytes(scrypthash[16:32], byteorder='big')
+        priv = half1.to_bytes(16, byteorder='big') + half2.to_bytes(16, byteorder='big')
+        priv_int = int.from_bytes(priv, byteorder='big')
+        if priv_int == 0 or priv_int >= secp256k1_n:
+            if outputlotsequence:
+                return False, False, False
+            else:
+                return False
+        pub = private_key_to_public_key(priv)
+        if flagbyte in COMPRESSION_FLAGBYTES:
+            privcompress = bytes([0x1])
+            pub = compress(pub)
+        else:
+            privcompress = bytes([])
+        address = public_key_to_address(pub)
+        addrhex = bytearray(address, 'ascii')
+        addresshash = double_sha256(addrhex)[:4]
+        if addresshash == encpriv[3:7]:
+            priv = base58.b58encode_check(bytes([0x80]) + priv + privcompress)
+            if outputlotsequence:
+                return priv, False, False
+            else:
+                return priv
+        else:
+            if outputlotsequence:
+                return False, False, False
+            else:
+                return False
+    else:
+        owner_entropy = encpriv[7:15]
+        enchalf1half1 = encpriv[15:23]
+        enchalf2 = encpriv[23:]
+        if flagbyte in LOTSEQUENCE_FLAGBYTES:
+            lotsequence = owner_entropy[4:]
+            owner_salt = owner_entropy[:4]
+        else:
+            lotsequence = False
+            owner_salt = owner_entropy
+        prefactor = l_scrypt(password, owner_salt, 16384, 8, 8, 32)
+        if lotsequence is False:
+            passfactor = prefactor
+        else:
+            passfactor = double_sha256(prefactor + owner_entropy)
+        passfactor_int = int.from_bytes(passfactor, byteorder='big')
+        if passfactor_int == 0 or passfactor_int >= secp256k1_n:
+            if outputlotsequence:
+                return False, False, False
+            else:
+                return False
+        passpoint = compress(private_key_to_public_key(passfactor))
+        password = passpoint
+        encseedb = l_scrypt(password, encpriv[3:7] + owner_entropy, 1024, 1, 1, 64)
+        key = encseedb[32:]
+        aes = AESModeOfOperationECB(key)
+        tmp = aes.decrypt(enchalf2)
+        enchalf1half2_seedblastthird = int.from_bytes(tmp, byteorder='big') ^ int.from_bytes(encseedb[16:32], byteorder='big')
+        enchalf1half2_seedblastthird = enchalf1half2_seedblastthird.to_bytes(16, byteorder='big')
+        enchalf1half2 = enchalf1half2_seedblastthird[:8]
+        enchalf1 = enchalf1half1 + enchalf1half2
+        seedb = aes.decrypt(enchalf1)
+        seedb = int.from_bytes(seedb, byteorder='big') ^ int.from_bytes(encseedb[:16], byteorder='big')
+        seedb = seedb.to_bytes(16, byteorder='big') + enchalf1half2_seedblastthird[8:]
+        assert len(seedb) == 24
+        try:
+            factorb = double_sha256(seedb)
+            factorb_int = int.from_bytes(factorb, byteorder='big')
+            assert factorb_int != 0
+            assert not factorb_int >= secp256k1_n
+        except:
+            if outputlotsequence:
+                return False, False, False
+            else:
+                return False
+        priv = ((passfactor_int * factorb_int) % secp256k1_n).to_bytes(32, byteorder='big')
+        pub = private_key_to_public_key(priv)
+        if flagbyte in COMPRESSION_FLAGBYTES:
+            privcompress = bytes([0x1])
+            pub = compress(pub)
+        else:
+            privcompress = bytes([])
+        address = public_key_to_address(pub)
+        addrhex = bytearray(address, 'ascii')
+        addresshash = double_sha256(addrhex)[:4]
+        if addresshash == encpriv[3:7]:
+            priv = base58.b58encode_check(bytes([0x80]) + priv + privcompress)
+            if outputlotsequence:
+                if lotsequence is not False:
+                    lotsequence = int(lotsequence, 16)
+                    sequence = lotsequence % 4096
+                    lot = (lotsequence - sequence) // 4096
+                    return priv, lot, sequence
+                else:
+                    return priv, False, False
+            else:
+                return priv
+        else:
+            if outputlotsequence:
+                return False, False, False
+            else:
+                return False
+
+# @register_wallet_class - not a "registered" wallet since there are no wallet files nor extracts
+class WalletBIP38(object):
+    opencl_algo = -1
+
+    def __init__(self, enc_privkey):
+        global pylibscrypt, ecdsa, double_sha256, hash160, normalize, base58, AESModeOfOperationECB, secp256k1_n
+        import pylibscrypt, ecdsa
+        from bitcoinlib.config.secp256k1 import secp256k1_n
+        from bitcoinlib.encoding import double_sha256, hash160
+        from unicodedata import normalize
+        from cashaddress import base58
+        from pyaes import AESModeOfOperationECB
+
+        self.enc_privkey = enc_privkey
+
+    def __setstate__(self, state):
+        # (re-)load the required libraries after being unpickled
+        global pylibscrypt, ecdsa, double_sha256, hash160, normalize, base58, AESModeOfOperationECB, secp256k1_n
+        import pylibscrypt, ecdsa
+        from bitcoinlib.config.secp256k1 import secp256k1_n
+        from bitcoinlib.encoding import double_sha256, hash160
+        from unicodedata import normalize
+        from cashaddress import base58
+        from pyaes import AESModeOfOperationECB
+
+        self.__dict__ = state
+
+    def passwords_per_seconds(self, seconds):
+        return max(int(round(10 * seconds)), 1)
+
+    def difficulty_info(self):
+        return "scrypt N, r, p = 16384, 8, 8 and scrypt N, r, p = 1024, 1, 1"
+
+    def return_verified_password_or_false(self, passwords):
+        return self._return_verified_password_or_false_cpu(passwords)
+
+    # This is the time-consuming function executed by worker thread(s). It returns a tuple: if a password
+    # is correct return it, else return False for item 0; return a count of passwords checked for item 1
+    def _return_verified_password_or_false_cpu(self, passwords):
+        passwords = map(lambda p: normalize("NFC", p).encode("utf_8", "ignore"), passwords)
+        for count, password in enumerate(passwords, 1):
+            if bip38decrypt(password, self.enc_privkey):
+                return password.decode("utf_8", "replace"), count
+
+        return False, count
+
+
 ############### BIP-39 ###############
 
 # @register_wallet_class - not a "registered" wallet since there are no wallet files nor extracts
@@ -2753,6 +2941,9 @@ def init_parser_common():
         parser_common.add_argument("--pause",       action="store_true", help="pause before exiting")
         parser_common.add_argument("--version","-v",action="store_true", help="show full version information and exit")
         parser_common.add_argument("--disablesecuritywarnings", "--dsw", action="store_true", help="Disable Security Warning Messages")
+        bip38_group = parser_common.add_argument_group("BIP-38 passwords")
+        bip38_group.add_argument("--bip38",       action="store_true",   help="search for a BIP-38 password instead of from a wallet")
+        bip38_group.add_argument("--enc-privkey", metavar="ENC-PRIVKEY", help="encrypted private key")
         bip39_group = parser_common.add_argument_group("BIP-39 passwords")
         bip39_group.add_argument("--bip39",      action="store_true",   help="search for a BIP-39 password instead of from a wallet")
         bip39_group.add_argument("--mpk",        metavar="XPUB",        help="the master public key")
@@ -3267,12 +3458,13 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
     required_args = 0
     if args.wallet:       required_args += 1
     if args.data_extract: required_args += 1
+    if args.bip38:        required_args += 1
     if args.bip39:        required_args += 1
     if args.listpass:     required_args += 1
     if wallet:            required_args += 1
     if required_args != 1 and (args.seedgenerator == False):
         assert not wallet, 'custom wallet object not permitted with --wallet, --data-extract, --bip39, or --listpass'
-        error_exit("argument --wallet (or --data-extract, --bip39, or --listpass, exactly one) is required")
+        error_exit("argument --wallet (or --data-extract, --bip38, --bip39, or --listpass, exactly one) is required")
 
     # If specificed, use a custom wallet object instead of loading a wallet file or data-extract
     global loaded_wallet
@@ -3300,6 +3492,9 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
         if args.msigna_keychain and not isinstance(loaded_wallet, WalletMsigna):
             print("Warning: ignoring --msigna-keychain (wallet file is not an mSIGNA vault)")
 
+
+    if args.bip38:
+        loaded_wallet = WalletBIP38(args.enc_privkey)
 
     # Parse --bip39 related options, and create a WalletBIP39 object
     if args.bip39:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ green==3.1.1
 protobuf==3.11.3
 pycryptodome==3.9.7
 groestlcoin_hash==1.0.3
+ecdsa==0.16.0


### PR DESCRIPTION
This PR would allow having tokens separated by the specified delimiter if they are surrounded by quotation marks.

For a whitespace delimiter and a file `tokens.txt`:
```
A B C
D E F
G H
```

It is currently not possible to try the token `A B` since separating `A` and `B` with a space would mean that either one of them should be tried, but with PR, it's possible to try `A B` as a single token by the changing the file `tokens.txt`:

```
"A B" C
D E F
G H
```
When a quotation mark is needed as a part of a token, it can be skipped by placing the escape char `\` before it.